### PR TITLE
Restyle WhatsApp end-of-flow banner

### DIFF
--- a/main
+++ b/main
@@ -983,9 +983,11 @@ function CtaNudgeOverlay({
 function HunFullScreenBanner({
     visible,
     message,
+    onClose,
 }: {
     visible: boolean
     message: string
+    onClose?: () => void
 }) {
     return (
         <Portal>
@@ -1007,77 +1009,250 @@ function HunFullScreenBanner({
                             padding: "96px 20px 40px",
                             gap: 32,
                             zIndex: 2147483646,
-                            pointerEvents: "none",
+                            pointerEvents: "auto",
                         }}
                     >
                         <motion.div
-                            initial={{ y: -20, opacity: 0 }}
+                            initial={{ y: -24, opacity: 0 }}
                             animate={{ y: 0, opacity: 1 }}
-                            exit={{ y: 10, opacity: 0 }}
+                            exit={{ y: 16, opacity: 0 }}
                             transition={{ type: "spring", stiffness: 360, damping: 32 }}
                             style={{
                                 display: "grid",
-                                placeItems: "center",
-                                gap: 14,
-                                width: "min(480px, 100%)",
-                                background: "#FFFFFF",
-                                borderRadius: 24,
-                                padding: "28px 24px",
-                                boxShadow: "0 30px 90px rgba(0,0,0,0.45)",
-                                textAlign: "center",
-                                pointerEvents: "none",
+                                gap: 22,
+                                width: "min(520px, 100%)",
+                                pointerEvents: "auto",
                             }}
                         >
                             <div
                                 style={{
-                                    fontSize: 22,
-                                    fontWeight: 900,
-                                    color: wa.header,
+                                    borderRadius: 22,
+                                    padding: "24px 24px 28px",
+                                    background: "rgba(255,255,255,0.95)",
+                                    boxShadow: "0 30px 90px rgba(0,0,0,0.45)",
                                 }}
                             >
-                                Payment confirmation ready on WhatsApp
+                                <div
+                                    style={{
+                                        display: "grid",
+                                        gap: 18,
+                                    }}
+                                >
+                                    <div
+                                        style={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: "center",
+                                            gap: 12,
+                                            color: wa.header,
+                                            fontSize: 24,
+                                            fontWeight: 900,
+                                            letterSpacing: 0.3,
+                                        }}
+                                    >
+                                        <span role="img" aria-label="WhatsApp">💬</span> Payment confirmation ready on WhatsApp
+                                    </div>
+                                    <div
+                                        style={{
+                                            display: "grid",
+                                            gap: 16,
+                                        }}
+                                    >
+                                        <div
+                                            style={{
+                                                fontSize: 18,
+                                                fontWeight: 700,
+                                                lineHeight: 1.45,
+                                                color: "#0A1F44",
+                                                textAlign: "center",
+                                            }}
+                                        >
+                                            {message}
+                                        </div>
+                                        <div
+                                            style={{
+                                                fontSize: 14,
+                                                fontWeight: 600,
+                                                color: "rgba(10,31,68,0.8)",
+                                                textAlign: "center",
+                                            }}
+                                        >
+                                            Tap the WhatsApp notification banner above to open the receipt and finish the flow.
+                                        </div>
+                                    </div>
+                                </div>
                             </div>
-                            <div
-                                style={{
-                                    fontSize: 18,
-                                    fontWeight: 700,
-                                    lineHeight: 1.4,
-                                    color: "#0A1F44",
-                                }}
-                            >
-                                {message}
-                            </div>
-                            <div
-                                style={{
-                                    fontSize: 14,
-                                    fontWeight: 600,
-                                    color: "rgba(10,31,68,0.85)",
-                                }}
-                            >
-                                Tap the WhatsApp notification banner above to view the receipt and
-                                continue the conversation.
-                            </div>
-                        </motion.div>
 
-                        <motion.div
-                            initial={{ opacity: 0, scale: 0.92 }}
-                            animate={{ opacity: [0.5, 1, 0.5], scale: [0.9, 1.05, 0.9] }}
-                            transition={{ repeat: Infinity, duration: 1.6, ease: "easeInOut" }}
-                            style={{
-                                display: "flex",
-                                alignItems: "center",
-                                justifyContent: "center",
-                                gap: 12,
-                                padding: "12px 20px",
-                                borderRadius: 999,
-                                background: "rgba(255,255,255,0.2)",
-                                color: "#FFFFFF",
-                                fontWeight: 800,
-                                letterSpacing: 0.4,
-                                textTransform: "uppercase",
-                            }}
-                        >
-                            Tap the green WhatsApp banner now
+                            <motion.div
+                                initial={{ opacity: 0, y: -14 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{ delay: 0.08, duration: 0.4, ease: "easeOut" }}
+                                style={{
+                                    display: "flex",
+                                    justifyContent: "center",
+                                }}
+                            >
+                                <div
+                                    style={{
+                                        width: "min(520px, 100%)",
+                                        background: "rgba(14,63,54,0.85)",
+                                        borderRadius: 18,
+                                        padding: "20px 22px",
+                                        boxShadow: "0 22px 60px rgba(0,0,0,0.38)",
+                                        color: "#fff",
+                                        display: "grid",
+                                        gap: 18,
+                                    }}
+                                >
+                                    <div
+                                        style={{
+                                            display: "flex",
+                                            alignItems: "center",
+                                            justifyContent: "space-between",
+                                            fontSize: 13,
+                                            fontWeight: 600,
+                                            opacity: 0.85,
+                                            letterSpacing: 0.2,
+                                            textTransform: "uppercase",
+                                        }}
+                                    >
+                                        <span style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                                            <span
+                                                style={{
+                                                    width: 18,
+                                                    height: 18,
+                                                    borderRadius: 6,
+                                                    background: "#25D366",
+                                                    display: "grid",
+                                                    placeItems: "center",
+                                                    fontSize: 11,
+                                                    fontWeight: 900,
+                                                }}
+                                            >
+                                                WA
+                                            </span>
+                                            WhatsApp
+                                        </span>
+                                        <span>Now</span>
+                                    </div>
+                                    <div
+                                        style={{
+                                            display: "grid",
+                                            gap: 12,
+                                            background: "rgba(255,255,255,0.06)",
+                                            borderRadius: 14,
+                                            padding: "16px 18px",
+                                        }}
+                                    >
+                                        <div
+                                            style={{
+                                                display: "flex",
+                                                alignItems: "center",
+                                                justifyContent: "space-between",
+                                            }}
+                                        >
+                                            <div
+                                                style={{
+                                                    display: "flex",
+                                                    alignItems: "center",
+                                                    gap: 12,
+                                                }}
+                                            >
+                                                <div
+                                                    style={{
+                                                        width: 36,
+                                                        height: 36,
+                                                        borderRadius: 12,
+                                                        background: "#25D366",
+                                                        display: "grid",
+                                                        placeItems: "center",
+                                                        color: "#fff",
+                                                        fontWeight: 900,
+                                                    }}
+                                                >
+                                                    n
+                                                </div>
+                                                <div
+                                                    style={{
+                                                        display: "grid",
+                                                        gap: 2,
+                                                        color: "#FFFFFF",
+                                                    }}
+                                                >
+                                                    <div
+                                                        style={{
+                                                            fontSize: 16,
+                                                            fontWeight: 800,
+                                                        }}
+                                                    >
+                                                        Nugget Support
+                                                    </div>
+                                                    <div
+                                                        style={{
+                                                            fontSize: 13,
+                                                            opacity: 0.75,
+                                                        }}
+                                                    >
+                                                        “Receipt is ready, tap to view.”
+                                                    </div>
+                                                </div>
+                                            </div>
+                                            <div
+                                                style={{
+                                                    padding: "6px 12px",
+                                                    borderRadius: 999,
+                                                    background: "rgba(255,255,255,0.16)",
+                                                    fontSize: 13,
+                                                    fontWeight: 700,
+                                                }}
+                                            >
+                                                View
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div
+                                        style={{
+                                            fontSize: 12,
+                                            fontWeight: 600,
+                                            opacity: 0.85,
+                                            textAlign: "center",
+                                        }}
+                                    >
+                                        This is a preview of the heads-up WhatsApp banner that stays on-screen until you tap it.
+                                    </div>
+                                </div>
+                            </motion.div>
+
+                            {onClose && (
+                                <motion.div
+                                    initial={{ opacity: 0, y: 10 }}
+                                    animate={{ opacity: 1, y: 0 }}
+                                    exit={{ opacity: 0, y: 10 }}
+                                    transition={{ delay: 0.12, duration: 0.35, ease: "easeOut" }}
+                                    style={{
+                                        display: "flex",
+                                        justifyContent: "center",
+                                    }}
+                                >
+                                    <button
+                                        onClick={onClose}
+                                        style={{
+                                            padding: "14px 32px",
+                                            borderRadius: 999,
+                                            border: 0,
+                                            background: "#1677FF",
+                                            color: "#FFFFFF",
+                                            fontWeight: 900,
+                                            fontSize: 16,
+                                            cursor: "pointer",
+                                            boxShadow: "0 18px 40px rgba(22,119,255,0.45)",
+                                            letterSpacing: 0.2,
+                                        }}
+                                    >
+                                        OK, got it
+                                    </button>
+                                </motion.div>
+                            )}
                         </motion.div>
                     </motion.div>
                 )}
@@ -2545,6 +2720,7 @@ export default function Upigff({
                     <HunFullScreenBanner
                         visible={showHunBanner && showHUN}
                         message={NUDGE_HUN}
+                        onClose={() => setShowHunBanner(false)}
                     />
 
                     {/* Spotlight for HUN (optional nudge) */}


### PR DESCRIPTION
## Summary
- refresh the WhatsApp end-of-flow banner to look like the desired heads-up experience
- add a detailed preview of the WhatsApp notification and updated copy for the guidance card
- surface an "OK, got it" action with richer styling while keeping the notification active until tapped

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4adb37bec832fb38cf2c97e87b363